### PR TITLE
Logging errors

### DIFF
--- a/src/icarus_v2/backend/data_handler.py
+++ b/src/icarus_v2/backend/data_handler.py
@@ -57,7 +57,6 @@ class DataHandler(QThread):
         # TESTING ONLY!!!. reads a raw data file instead of connecting to a device
         # edit raw_file to change the playback to a different file
         self.load_raw = False
-        # self.load_raw = True #This is for testing adding errors to log files
         if self.load_raw:
             raw_file = "2.1_to_1.5kBar.xz"
             project_root = Path(__file__).resolve().parents[3]
@@ -112,7 +111,7 @@ class DataHandler(QThread):
         self.sentry.error_signal.connect(lambda x: self.shutdown_signal.emit())
 
         # Logger
-        if not self.load_raw:#TODO: uncomment
+        if not self.load_raw:
             self.logger = Logger()
             self.pressurize_event_signal.connect(self.logger.log_event)
             self.depressurize_event_signal.connect(self.logger.log_event)

--- a/src/icarus_v2/backend/data_handler.py
+++ b/src/icarus_v2/backend/data_handler.py
@@ -35,7 +35,7 @@ class DataHandler(QThread):
     # display error dialog
     display_error = Signal(str)
     # Show warning or error in toolbar
-    toolbar_warning = Signal(str)
+    toolbar_warning = Signal(str,str)
     # Signal to tell device control panel to shut down
     # Ideally this is unnecessary as the signal should be directly sent to the pulse_generator
     # But currently the control panel can not check the state of the device. This is a workaround.
@@ -106,8 +106,8 @@ class DataHandler(QThread):
         self.log_signal.connect(self.sentry.handle_experiment)
         self.pump_event_signal.connect(self.sentry.handle_pump)
         self.depressurize_event_signal.connect(self.sentry.handle_depressurize)
-        self.sentry.warning_signal.connect(lambda x: self.toolbar_warning.emit(x))
-        self.sentry.error_signal.connect(lambda x: self.toolbar_warning.emit(str(x))) #TODO: Determine whether to cast as string or convert to new class
+        self.sentry.warning_signal.connect(lambda x: self.toolbar_warning.emit(str(x),"orange"))
+        self.sentry.error_signal.connect(lambda x: self.toolbar_warning.emit(str(x),"red")) 
         self.sentry.error_signal.connect(lambda x: self.display_error.emit(str(x))) 
         self.sentry.error_signal.connect(lambda x: self.shutdown_signal.emit())
 
@@ -119,11 +119,11 @@ class DataHandler(QThread):
             self.period_event_signal.connect(self.logger.log_event)
             self.log_signal.connect(self.logger.new_log_file)
 
-        # self.display_error.connect(self.logger.log_error)
-        # self.toolbar_warning.connect(self.logger.log_error)
+            # self.display_error.connect(self.logger.log_error)
+            # self.toolbar_warning.connect(self.logger.log_error)
 
-        self.sentry.warning_signal.connect(self.logger.log_error)
-        self.sentry.error_signal.connect(self.logger.log_error)
+            self.sentry.warning_signal.connect(self.logger.log_error)
+            self.sentry.error_signal.connect(self.logger.log_error)
 
         # Sample sensor detector
         self.sample_sensor_detector = SampleSensorDetector(self.sample_sensor_connected)

--- a/src/icarus_v2/backend/log_reader.py
+++ b/src/icarus_v2/backend/log_reader.py
@@ -30,6 +30,10 @@ class LogReader:
                 event_dict = pickle.load(file)
                 if "plotting_coefficients" in event_dict.keys():
                     self.log_coefficients = event_dict["plotting_coefficients"]
+                elif "error_type" in event_dict.keys():
+                    event = event_dict['class_type'](event_dict['error_type'],event_dict['event_time'],event_dict['data'])
+
+                    # print(event)
                 else:
                     event = Event(
                         event_dict['event_type'],

--- a/src/icarus_v2/backend/log_reader.py
+++ b/src/icarus_v2/backend/log_reader.py
@@ -1,15 +1,17 @@
 import lzma
 import pickle
 from icarus_v2.backend.event import Event
+from icarus_v2.backend.sentry_error import SentryError
 
 
 # Load events from logs
 class LogReader:
-    def __init__(self) -> None:
+    def __init__(self, tool_bar=None,) -> None:
         self.events = None
         self.filename = None
         self.logger = None
         self.log_coefficients = None
+        self.tool_bar=tool_bar
 
     def set_logger(self, logger):
         self.logger = logger
@@ -32,8 +34,11 @@ class LogReader:
                     self.log_coefficients = event_dict["plotting_coefficients"]
                 elif "error_type" in event_dict.keys():
                     event = event_dict['class_type'](event_dict['error_type'],event_dict['event_time'],event_dict['data'])
+                    color="orange"
+                    if(type(event) == SentryError):
+                        color = "red"
 
-                    # print(event)
+                    self.tool_bar.display_warning("LOG: "+str(event),color)
                 else:
                     event = Event(
                         event_dict['event_type'],

--- a/src/icarus_v2/backend/logger.py
+++ b/src/icarus_v2/backend/logger.py
@@ -48,10 +48,21 @@ class Logger:
         }   
         self.log_raw(event_dict)
 
-    def log_raw(self, data):
-        if not self.is_raw:
-            raise RuntimeError("Error: Adding raw data to an event log.")
+    def log_error(self, event): 
+        #Should take in an instance of either sentry_error or sentry_warning
+        if self.is_raw:
+            raise RuntimeError("Error: Adding a processed error to a raw log.")
 
+        event_dict = {
+            'class_type' : type(event),     #This serves as a flag so that when the log is read it will know if it is a warning or error
+            'error_type' : event.error_type,
+            'event_time': event.time,
+            'data': event.info
+        }   
+
+        self.log_raw(event_dict)
+
+    def log_raw(self, data):
         self.event_count += 1
         pickle.dump(data, self.file, protocol=pickle.HIGHEST_PROTOCOL)
 

--- a/src/icarus_v2/backend/sentry.py
+++ b/src/icarus_v2/backend/sentry.py
@@ -2,12 +2,14 @@ import numpy as np
 from PySide6.QtCore import QThread, Signal
 from icarus_v2.backend.event import get_channel, Channel
 from icarus_v2.backend.configuration_manager import ConfigurationManager
+from icarus_v2.backend.sentry_error import SentryError
+from icarus_v2.backend.sentry_warning import SentryWarning
 from time import localtime, strftime
 
 # Gets expected values for the experiment checks from the first example_events events of an experiment
 class Sentry(QThread):
-    warning_signal = Signal(str)
-    error_signal = Signal(str)
+    warning_signal = Signal(SentryWarning)
+    error_signal = Signal(SentryError)
 
     def __init__(self):
         super().__init__()
@@ -43,6 +45,9 @@ class Sentry(QThread):
         # update this only here so it is not changed for an ongoing experiment
         self.current_example_events = self.settings['example_events']
 
+        #TODO: Get rid of
+        # self.current_experiment = True
+
     def handle_pump(self, event):
         if self.current_experiment:
             self.example_pump_times.append(event.event_time)
@@ -58,18 +63,22 @@ class Sentry(QThread):
                 rate_percent_increase = (pump_rate - self.expected_pump_rate) / self.expected_pump_rate
                 if event.event_time - self.last_error_time > self.suppress_errors:
                     if rate_percent_increase > self.settings["max_pump_rate_increase"]:
-                        self.warning_signal.emit(
-                            f"Warning: pump rate at {strftime('%H:%M:%S', localtime(event.event_time))} is "
-                            f"{pump_rate:.2f}, which is {rate_percent_increase:.2f}% over the expected rate from the "
-                            "beginning of the experiment. Possible leak.")
+                        info = {
+                            "pump_rate" : pump_rate,
+                            "rate_percent_increase" : rate_percent_increase
+                        }
+                        self.warning_signal.emit(SentryWarning("Pump Rate High",localtime(event.event_time),info))
 
             # check for max_pumps within pump_window
             self.recent_pump_times.append(event.event_time)
             self.recent_pump_times = [t for t in self.recent_pump_times if t > event.event_time - self.settings["pump_window"]]
             if event.event_time - self.last_error_time > self.suppress_errors:
                 if len(self.recent_pump_times) > self.settings["max_pumps_in_window"]:
-                    self.error_signal.emit(
-                        f"Error: {len(self.recent_pump_times)} pump strokes occurred within {self.settings['pump_window']} seconds.")
+                    info = {
+                        "recent_pump_times" : self.recent_pump_times,
+                        "pump_window" : self.settings['pump_window']
+                    }
+                    self.error_signal.emit(SentryError("Pump Rate High",localtime(event.event_time),info))
                     self.last_error_time = event.event_time
 
     def handle_depressurize(self, event):
@@ -89,22 +98,20 @@ class Sentry(QThread):
                     self.num_pressure_decreases += 1
                     if event.event_time - self.last_error_time > self.suppress_errors:
                         if self.num_pressure_decreases >= self.settings["decrease_count_to_error"]:
-                            self.error_signal.emit(
-                                f"Error: pressure decreased {self.num_pressure_decreases} times in a row at "
-                                f"{strftime('%H:%M:%S', localtime(event.event_time))}. Likely leak")
+                            info = {
+                                "num_pressure_decreases" : self.num_pressure_decreases
+                            }
+                            self.error_signal.emit(SentryError("Pressure Decreasing",localtime(event.event_time),info))
+
                             self.last_error_time = event.event_time
                         else:
-                            self.warning_signal.emit(
-                                f"Warning: pressure decreasing at "
-                                f"{strftime('%H:%M:%S', localtime(event.event_time))}. Possible leak.")
+                            self.warning_signal.emit(SentryError("Pressure Decreasing",localtime(event.event_time)))
                 else:
                     self.num_pressure_decreases = 0
 
                 if event.event_time - self.last_error_time > self.suppress_errors:
                     if percent_change > self.settings["max_pressure_before_depress_increase"]:
-                        self.warning_signal.emit(
-                            f"Warning: pressure increasing at "
-                            f"{strftime('%H:%M:%S', localtime(event.event_time))}. Possible leak.")
+                        self.error_signal.emit(SentryError("Pressure Increasing",localtime(event.event_time)))
 
     # On device disconnect
     def reset(self):

--- a/src/icarus_v2/backend/sentry.py
+++ b/src/icarus_v2/backend/sentry.py
@@ -105,13 +105,13 @@ class Sentry(QThread):
 
                             self.last_error_time = event.event_time
                         else:
-                            self.warning_signal.emit(SentryError("Pressure Decreasing",localtime(event.event_time)))
+                            self.warning_signal.emit(SentryWarning("Pressure Decreasing",localtime(event.event_time)))
                 else:
                     self.num_pressure_decreases = 0
 
                 if event.event_time - self.last_error_time > self.suppress_errors:
                     if percent_change > self.settings["max_pressure_before_depress_increase"]:
-                        self.error_signal.emit(SentryError("Pressure Increasing",localtime(event.event_time)))
+                        self.warning_signal.emit(SentryWarning("Pressure Increasing",localtime(event.event_time)))
 
     # On device disconnect
     def reset(self):

--- a/src/icarus_v2/backend/sentry.py
+++ b/src/icarus_v2/backend/sentry.py
@@ -45,9 +45,6 @@ class Sentry(QThread):
         # update this only here so it is not changed for an ongoing experiment
         self.current_example_events = self.settings['example_events']
 
-        #TODO: Get rid of
-        # self.current_experiment = True
-
     def handle_pump(self, event):
         if self.current_experiment:
             self.example_pump_times.append(event.event_time)

--- a/src/icarus_v2/backend/sentry_error.py
+++ b/src/icarus_v2/backend/sentry_error.py
@@ -1,0 +1,16 @@
+class SentryError(RuntimeError):
+    def __init__(self, error_type, time, info=None):
+        self.error_type = error_type
+        self.time = time
+        self.info = info
+
+    def __str__(self):
+        if self.error_type == "Pump Rate High":
+            return (
+                f"Error: {len(self.info["recent_pump_times"])} pump strokes occurred within {self.info['pump_window']} seconds.")
+        elif self.error_type == "Pressure Decreasing":
+            return (
+                f"Error: pressure decreased {self.info["num_pressure_decreases"]} times in a row at "
+                f"{strftime('%H:%M:%S', self.time)}. Likely leak")
+        
+        return "Unknown Error"

--- a/src/icarus_v2/backend/sentry_error.py
+++ b/src/icarus_v2/backend/sentry_error.py
@@ -1,3 +1,5 @@
+from time import strftime
+
 class SentryError(RuntimeError):
     def __init__(self, error_type, time, info=None):
         self.error_type = error_type

--- a/src/icarus_v2/backend/sentry_warning.py
+++ b/src/icarus_v2/backend/sentry_warning.py
@@ -1,0 +1,22 @@
+class SentryWarning(Warning):
+    def __init__(self, error_type, time, info=None):
+        self.error_type = error_type
+        self.time = time
+        self.info = info
+
+    def __str__(self):
+        if self.error_type == "Pump Rate High":
+            return (
+                f"Warning: pump rate at {strftime('%H:%M:%S', self.time)} is "
+                f"{self.info["pump_rate"]:.2f}, which is {self.info["rate_percent_increase"]:.2f}% over the expected rate from the "
+                "beginning of the experiment. Possible leak.")
+        elif self.error_type == "Pressure Decreasing":
+            return (
+                f"Warning: pressure decreasing at "
+                f"{strftime('%H:%M:%S', self.time)}. Possible leak.")
+        elif self.error_type == "Pressure Increasing":
+            return (
+                f"Warning: pressure increasing at "
+                f"{strftime('%H:%M:%S', self.time)}. Possible leak.")
+        
+        return "Unknown Warning"

--- a/src/icarus_v2/backend/sentry_warning.py
+++ b/src/icarus_v2/backend/sentry_warning.py
@@ -1,3 +1,5 @@
+from time import strftime
+
 class SentryWarning(Warning):
     def __init__(self, error_type, time, info=None):
         self.error_type = error_type

--- a/src/icarus_v2/gui/log_control_panel.py
+++ b/src/icarus_v2/gui/log_control_panel.py
@@ -32,10 +32,10 @@ class LogControlPanel(QGroupBox):
     sample_sensor_connected = Signal(bool)
     log_coefficients_signal = Signal(object)
 
-    def __init__(self, parent=None):
+    def __init__(self, parent=None, tool_bar=None):
         super().__init__(parent=parent)
 
-        self.log_reader = LogReader()
+        self.log_reader = LogReader(tool_bar=tool_bar)
         self.press_index = None
         self.depress_index = None
         self.period_index = None

--- a/src/icarus_v2/gui/main_window.py
+++ b/src/icarus_v2/gui/main_window.py
@@ -50,7 +50,13 @@ class MainWindow(QMainWindow):
         self.counter_display = CounterDisplay()
         self.pressure_display = PressureDisplay()
 
-        self.log_control_panel = LogControlPanel()
+        # ToolBar
+        self.toolbar = ToolBar(self)
+        self.addToolBar(self.toolbar)
+        self.toolbar.set_mode_signal.connect(self.set_mode)
+        self.toolbar.history_reset_action.triggered.connect(self.reset_history)
+
+        self.log_control_panel = LogControlPanel(tool_bar=self.toolbar)
         self.log_control_panel.pressurize_event_signal.connect(self.pressurize_plot.update_data)
         self.log_control_panel.pressurize_event_signal.connect(self.history_plot.render_pressurize_time)
         self.log_control_panel.depressurize_event_signal.connect(self.depressurize_plot.update_data)
@@ -64,12 +70,6 @@ class MainWindow(QMainWindow):
         self.log_control_panel.log_coefficients_signal.connect(self.period_plot.set_log_coefficients)
         self.log_control_panel.log_coefficients_signal.connect(self.history_plot.set_log_coefficients)
         self.log_control_panel.setSizePolicy(QSizePolicy.Expanding, QSizePolicy.Expanding)
-
-        # ToolBar
-        self.toolbar = ToolBar(self)
-        self.addToolBar(self.toolbar)
-        self.toolbar.set_mode_signal.connect(self.set_mode)
-        self.toolbar.history_reset_action.triggered.connect(self.reset_history)
 
         # Control and value layout
         # Show bounding box even when no controls are displayed

--- a/src/icarus_v2/gui/scrollable_menu.py
+++ b/src/icarus_v2/gui/scrollable_menu.py
@@ -69,8 +69,9 @@ class ScrollableMenu(QMenu):
     def return_matching(self, seq):
         matching = []
         for i in range(self.layout.count()):
-            label=self.layout.itemAt(i).widget().text() #TODO: should test response for if a non label object gets added to the list
-            if(label is not None):
+            widget=self.layout.itemAt(i).widget()
+            if(hasattr(widget,'text')):
+                label = widget.text() 
                 if(seq in label):
                     matching += [self.layout.itemAt(i)]
         return matching
@@ -89,8 +90,6 @@ class ScrollableMenu(QMenu):
             
             #Remove from the layout
             self.layout.removeItem(item)
-            
-        #TODO: fix issue where items are still visible even if removed
 
 class WrappedLabel(QLabel):
     def __init__(self, text, color, parent=None):

--- a/src/icarus_v2/gui/scrollable_menu.py
+++ b/src/icarus_v2/gui/scrollable_menu.py
@@ -63,6 +63,34 @@ class ScrollableMenu(QMenu):
             new_value = scroll_bar.value() + label.sizeHint().height()
             scroll_bar.setValue(new_value)
 
+    '''
+    #Returns a list of any widgets in the layout that include the given string
+    '''
+    def return_matching(self, seq):
+        matching = []
+        for i in range(self.layout.count()):
+            label=self.layout.itemAt(i).widget().text() #TODO: should test response for if a non label object gets added to the list
+            if(label is not None):
+                if(seq in label):
+                    matching += [self.layout.itemAt(i)]
+        return matching
+
+    '''
+    #Given a list of widgets will go through and remove each one
+    #If only one widget is being removed in shoudl be passed in wrapped in []
+    '''
+    def remove_items(self,items):
+        for item in items:
+            #This clears them from the scroll menu
+            if item:
+                widget = item.widget()
+                if widget:
+                    widget.deleteLater()
+            
+            #Remove from the layout
+            self.layout.removeItem(item)
+            
+        #TODO: fix issue where items are still visible even if removed
 
 class WrappedLabel(QLabel):
     def __init__(self, text, color, parent=None):

--- a/src/icarus_v2/gui/tool_bar.py
+++ b/src/icarus_v2/gui/tool_bar.py
@@ -80,6 +80,7 @@ class ToolBar(QToolBar):
         if self.settings_dialog is not None:
             self.settings_dialog.set_connected(connected)
 
-    def display_warning(self, warning):
+    def display_warning(self, warning, color="orange"):
+        self.warning_button.setStyleSheet("color: "+color+"; font-size: 12pt; text-align: left;")
         self.warning_button.setText(warning)
-        self.messages_menu.add_message(warning, color="orange")
+        self.messages_menu.add_message(warning, color)

--- a/src/icarus_v2/gui/tool_bar.py
+++ b/src/icarus_v2/gui/tool_bar.py
@@ -65,6 +65,8 @@ class ToolBar(QToolBar):
             self.change_mode_action.setText("Open Logs")
             self.set_mode_signal.emit("device")
 
+            self.clear_log_toolbar()
+
     def set_pressure_signal(self, pressure_signal):
         self.pressure_signal = pressure_signal
         if self.settings_dialog is not None:
@@ -84,3 +86,9 @@ class ToolBar(QToolBar):
         self.warning_button.setStyleSheet("color: "+color+"; font-size: 12pt; text-align: left;")
         self.warning_button.setText(warning)
         self.messages_menu.add_message(warning, color)
+
+    def clear_log_toolbar(self):
+        logs = self.messages_menu.return_matching("LOG:")
+        self.messages_menu.remove_items(logs)
+        if("LOG:" in self.warning_button.text()):
+            self.warning_button.setText("")

--- a/src/icarus_v2/gui/tool_bar.py
+++ b/src/icarus_v2/gui/tool_bar.py
@@ -87,6 +87,10 @@ class ToolBar(QToolBar):
         self.warning_button.setText(warning)
         self.messages_menu.add_message(warning, color)
 
+    '''
+    #Clears any log warnings or errors from the toolbar
+    #Called whenever the log is closed
+    '''
     def clear_log_toolbar(self):
         logs = self.messages_menu.return_matching("LOG:")
         self.messages_menu.remove_items(logs)


### PR DESCRIPTION
Implementation:
Warnings and Errors during experiments will now be recorded into log files. 
If a log file that had warnings or errors is opened, those warnings will be added to the toolbar with a "LOG:" prefix. 
When the log is closed any log messages will be removed from the toolbar.
Errors now show up in the toolbar as red (Warnings still appear as orange).

Testing done:
Verified that the toolbar only clears out messages with the provided string ("LOG:")
Fixed potential bug if a widget that is not a wrapped label is added to the scrollable menu layout
Tested reopening the log file after closing it
Tested opening a second log file while the first is still open

## Summary by Sourcery

Implement logging of warnings and errors during experiments, displaying them in the toolbar with color coding. Refactor error and warning handling to use structured classes for improved clarity and maintainability. Ensure the toolbar can manage log messages effectively, including clearing and handling multiple log files.

New Features:
- Introduce logging of warnings and errors during experiments into log files, with display in the toolbar.

Enhancements:
- Refactor error and warning handling to use SentryError and SentryWarning classes for better structure and clarity.

Tests:
- Test the toolbar's ability to clear messages with a specific prefix and handle multiple log files.