### PR TITLE
Add pressure update after interval

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "icarus_v2"
-version = "0.2.1"
+version = "0.3.1"
 description = "Monitoring software for the Icarus Pressure Jump apparatus"
 authors = ["Sean Fitch <fitchs2@rpi.edu>"]
 readme = "README.md"

--- a/src/icarus_v2/backend/data_handler.py
+++ b/src/icarus_v2/backend/data_handler.py
@@ -116,6 +116,7 @@ class DataHandler(QThread):
             self.pressurize_event_signal.connect(self.logger.log_event)
             self.depressurize_event_signal.connect(self.logger.log_event)
             self.period_event_signal.connect(self.logger.log_event)
+            self.pressure_event_signal.connect(self.logger.log_event)
             self.log_signal.connect(self.logger.new_log_file)
 
             # self.display_error.connect(self.logger.log_error)

--- a/src/icarus_v2/backend/data_handler.py
+++ b/src/icarus_v2/backend/data_handler.py
@@ -242,8 +242,14 @@ class DataHandler(QThread):
         self.pulse_generator.wait()
 
         if self.connected:
-            self.pulse_generator.set_pressurize_low()
-            self.pulse_generator.set_depressurize_low()
+            try:
+                self.pulse_generator.set_pressurize_low()
+            except:
+                pass
+            try:
+                self.pulse_generator.set_depressurize_low()
+            except:
+                pass
             sleep(1)
             self.pulse_generator.set_pressurize_high()
             self.pulse_generator.set_depressurize_high()

--- a/src/icarus_v2/backend/event.py
+++ b/src/icarus_v2/backend/event.py
@@ -190,7 +190,7 @@ class Event:
 
     # Returns pressure before event starts
     def get_initial_sample(self):
-        if self.event_type != self.DEPRESSURIZE:
+        if self.event_type != self.DEPRESSURIZE and self.event_type != self.PRESSURE:
             raise RuntimeError("Cannot call get_initial_sample() on event type " + self.event_type)
 
         sample_pressure = np.average(get_channel(self, Channel.HI_PRE_SAMPLE)[:self.event_index])
@@ -198,7 +198,7 @@ class Event:
 
     # Returns pressure before event starts
     def get_initial_origin(self):
-        if self.event_type != self.DEPRESSURIZE:
+        if self.event_type != self.DEPRESSURIZE and self.event_type != self.PRESSURE:
             raise RuntimeError("Cannot call get_initial_origin() on event type " + self.event_type)
 
         origin_pressure = np.average(get_channel(self, Channel.HI_PRE_ORIG)[:self.event_index])

--- a/src/icarus_v2/backend/logger.py
+++ b/src/icarus_v2/backend/logger.py
@@ -48,7 +48,9 @@ class Logger:
         }   
         self.log_raw(event_dict)
 
-    def log_error(self, event): 
+    def log_error(self, event):
+        return
+
         #Should take in an instance of either sentry_error or sentry_warning
         if self.is_raw:
             raise RuntimeError("Error: Adding a processed error to a raw log.")

--- a/src/icarus_v2/gui/history_plot.py
+++ b/src/icarus_v2/gui/history_plot.py
@@ -6,7 +6,7 @@ from icarus_v2.gui.styled_plot_widget import StyledPlotWidget
 from icarus_v2.backend.configuration_manager import ConfigurationManager
 
 
-MAX_PRESSURE_INTERVAL = 60
+MAX_PRESSURE_INTERVAL = 5
 
 
 class HistoryPlot(QWidget):
@@ -196,7 +196,7 @@ class HistoryPlot(QWidget):
             self.coefficients = self.define_coefficients(plotting_coefficients)
 
     def render_event_time(self, event):
-        time = event.event_time - self.initial_time
+        time = None if event is None else event.event_time - self.initial_time
         self.pressure_plot.add_vertical_line(event.event_type, time)
         self.slope_plot.add_vertical_line(event.event_type, time)
         self.switch_time_plot.add_vertical_line(event.event_type, time)

--- a/src/icarus_v2/gui/log_control_panel.py
+++ b/src/icarus_v2/gui/log_control_panel.py
@@ -269,7 +269,13 @@ class LogControlPanel(QGroupBox):
             return
         event = self.log_reader.events[index]
 
-        if event.event_type == Event.PRESSURIZE:
+        if event.event_type == Event.PRESSURE:
+            self.press_index += 1
+            self.depress_index += 1
+            self.period_index += 1
+            self.emit_next_event()
+
+        elif event.event_type == Event.PRESSURIZE:
             self.press_index = index
             self.pressurize_event_signal.emit(event)
 
@@ -303,7 +309,13 @@ class LogControlPanel(QGroupBox):
             return
         event = self.log_reader.events[index]
 
-        if event.event_type == Event.PRESSURIZE:
+        if event.event_type == Event.PRESSURE:
+            self.press_index -= 1
+            self.depress_index -= 1
+            self.period_index -= 1
+            self.emit_last_event()
+
+        elif event.event_type == Event.PRESSURIZE:
             self.press_index = index
             self.pressurize_event_signal.emit(event)
 

--- a/src/icarus_v2/gui/log_control_panel.py
+++ b/src/icarus_v2/gui/log_control_panel.py
@@ -270,10 +270,12 @@ class LogControlPanel(QGroupBox):
         event = self.log_reader.events[index]
 
         if event.event_type == Event.PRESSURE:
-            self.press_index += 1
-            self.depress_index += 1
-            self.period_index += 1
-            self.emit_next_event()
+            index = max(self.press_index, self.depress_index, self.period_index) + 1
+            while index < len(self.log_reader.events) and self.log_reader.events[index].event_type == Event.PRESSURE:
+                self.press_index += 1
+                self.depress_index += 1
+                self.period_index += 1
+            self.emit_last_event()
 
         elif event.event_type == Event.PRESSURIZE:
             self.press_index = index
@@ -310,9 +312,11 @@ class LogControlPanel(QGroupBox):
         event = self.log_reader.events[index]
 
         if event.event_type == Event.PRESSURE:
-            self.press_index -= 1
-            self.depress_index -= 1
-            self.period_index -= 1
+            index = min(self.press_index, self.depress_index, self.period_index) - 1
+            while index >= 0 and self.log_reader.events[index].event_type == Event.PRESSURE:
+                self.press_index -= 1
+                self.depress_index -= 1
+                self.period_index -= 1
             self.emit_last_event()
 
         elif event.event_type == Event.PRESSURIZE:

--- a/src/icarus_v2/gui/main_window.py
+++ b/src/icarus_v2/gui/main_window.py
@@ -183,6 +183,7 @@ class MainWindow(QMainWindow):
                 self.data_handler.period_event_signal.disconnect(self.period_plot.update_data)
                 self.data_handler.pressurize_event_signal.disconnect(self.history_plot.add_event)
                 self.data_handler.depressurize_event_signal.disconnect(self.history_plot.add_event)
+                self.data_handler.pressure_event_signal.disconnect(self.history_plot.add_event)
                 self.data_handler.log_signal.disconnect(self.reset_history)
                 self.data_handler.sample_sensor_connected.disconnect(self.set_sample_sensor_connected)
 
@@ -206,6 +207,7 @@ class MainWindow(QMainWindow):
                 self.data_handler.period_event_signal.connect(self.period_plot.update_data)
                 self.data_handler.pressurize_event_signal.connect(self.history_plot.add_event)
                 self.data_handler.depressurize_event_signal.connect(self.history_plot.add_event)
+                self.data_handler.pressure_event_signal.connect(self.history_plot.add_event)
                 self.data_handler.log_signal.connect(self.reset_history)
                 self.data_handler.sample_sensor_connected.connect(self.set_sample_sensor_connected)
 

--- a/src/icarus_v2/gui/styled_plot_widget.py
+++ b/src/icarus_v2/gui/styled_plot_widget.py
@@ -229,6 +229,9 @@ class StyledPlotWidget(PlotWidget):
         if channel in self.lines:
             self.removeItem(self.lines[channel])
 
+        if x is None:
+            return
+
         line_color = self.get_line_style(channel)[0]
         pen = pg.mkPen(color=line_color)
 

--- a/src/icarus_v2/gui/tool_bar.py
+++ b/src/icarus_v2/gui/tool_bar.py
@@ -66,8 +66,6 @@ class ToolBar(QToolBar):
             self.change_mode_action.setText("Open Logs")
             self.set_mode_signal.emit("device")
 
-            self.clear_log_toolbar()
-
     def set_pressure_signal(self, pressure_signal):
         self.pressure_signal = pressure_signal
         if self.settings_dialog is not None:


### PR DESCRIPTION
* Implement a minimum interval between PRESSURE updates.
* Temporarily disable logging of sentry warnings and errors.